### PR TITLE
添加拆分后的小文件汇总功能

### DIFF
--- a/TiChange_for_lightning.sh
+++ b/TiChange_for_lightning.sh
@@ -44,7 +44,7 @@ while true ; do
                         TiChange_check_dir=${2}
 			TiChange_oper_file=${2}/TiChange_operating_csv_$perfix_hash_time;
                         TiChange_oper_dir=${2}/${perfix_hash_time}_operating_dir; shift 2;;
-                -m|--schema-meta)         echo "Option s == ${2}" ;
+                -m|--schema-meta)         echo "Option m == ${2}" ;
 			TiChange_meta_table=${2}; shift 2;;
                 -s|--separator_import)    echo "Option s == ${2}" ;
 			TiChange_separator=${2}; shift 2;;


### PR DESCRIPTION
当使用Tichange拆分多个大文件后，每个都会生成独立的目录，如果想使用lightning一次性导入的话需要手动把小文件汇集在一起，于是开发了这个小文件汇总功能，方便lightning导入。